### PR TITLE
Change read_wav and write_wav to accept generic IO types

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,8 +4,12 @@ extern crate wav;
 mod tests {
 	#[test]
 	fn test_wav() {
-		let (h,b) = wav::read_wav(std::path::Path::new("data/sine.wav")).unwrap();
+        use std::fs::File;
 
-		wav::write_wav(h, b, std::path::Path::new("data/output.wav")).unwrap();
+        let mut reader = File::open(std::path::Path::new("data/sine.wav")).unwrap();
+		let (h,b) = wav::read_wav(&mut reader).unwrap();
+
+        let mut writer = File::create(std::path::Path::new("data/output.wav")).unwrap();
+		wav::write_wav(h, b, &mut writer).unwrap();
 	}
 }


### PR DESCRIPTION
There are many cases in which someone might want to read or write from something other than a file (e.g. if this crate is used as part of an intermediate processing step).  Using `std::io::Read` and `std::io::Write` trait objects makes the crate much more versatile.